### PR TITLE
Bump version

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject duct/server.http.jetty "0.2.0"
+(defproject duct/server.http.jetty "0.2.1"
   :description "Integrant methods for running a Jetty web server"
   :url "https://github.com/duct-framework/server.http.jetty"
   :license {:name "Eclipse Public License"


### PR DESCRIPTION
After merging the previous PR with dependencies update, this library wasn't deployed.
Would be nice to deploy it because it causes conflicts when using figwheel-main